### PR TITLE
Add dependabot config to keep GitHub actions up-to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot will automatically open PRs to update the actions used in your workflows. You can also configure it for other dependency maintenance, it's not restricted to GitHub workflows. 