### PR TITLE
Use assert_allclose from numpy.testing instead of np.allclose in matrix comparison tests

### DIFF
--- a/nigsp/tests/test_laplacian.py
+++ b/nigsp/tests/test_laplacian.py
@@ -3,7 +3,8 @@
 from copy import deepcopy as dc
 
 import numpy as np
-from pytest import mark, raises
+from numpy.testing import assert_allclose
+from pytest import raises
 
 from nigsp.operations import laplacian
 
@@ -24,29 +25,29 @@ def test_compute_laplacian():
     L, deg = glap(adj)
     lapl, degree = laplacian.compute_laplacian(mtx)
 
-    assert np.allclose(lapl, L)
-    assert np.allclose(degree, deg)
+    assert_allclose(lapl, L)
+    assert_allclose(degree, deg)
 
     lapl, degree = laplacian.compute_laplacian(mtx, selfloops=True)
     L, deg = glap(mtx)
-    assert np.allclose(lapl, L)
-    assert np.allclose(degree, deg)
+    assert_allclose(lapl, L)
+    assert_allclose(degree, deg)
 
     rn_deg = np.random.rand(4)
     lapl, degree = laplacian.compute_laplacian(mtx, selfloops=rn_deg)
     adj = dc(mtx)
     adj[np.diag_indices(mtx.shape[0])] = rn_deg
     L, deg = glap(adj)
-    assert np.allclose(lapl, L)
-    assert np.allclose(degree, deg)
+    assert_allclose(lapl, L)
+    assert_allclose(degree, deg)
 
     lapl, degree = laplacian.compute_laplacian(mtx, selfloops="degree")
     adj[np.diag_indices(mtx.shape[0])] = 0
     _, deg = glap(adj)
     adj[np.diag_indices(mtx.shape[0])] = deg
     L, deg = glap(adj)
-    assert np.allclose(lapl, L)
-    assert np.allclose(degree, deg)
+    assert_allclose(lapl, L)
+    assert_allclose(degree, deg)
 
     mtx = mtx - mtx.mean()
 
@@ -57,18 +58,18 @@ def test_compute_laplacian():
 
     L, deg = glap(mtx_abs)
     lapl, degree = laplacian.compute_laplacian(mtx, negval="absolute", selfloops=True)
-    assert np.allclose(lapl, L)
-    assert np.allclose(degree, deg)
+    assert_allclose(lapl, L)
+    assert_allclose(degree, deg)
 
     L, deg = glap(mtx_rem)
     lapl, degree = laplacian.compute_laplacian(mtx, negval="remove", selfloops=True)
-    assert np.allclose(lapl, L)
-    assert np.allclose(degree, deg)
+    assert_allclose(lapl, L)
+    assert_allclose(degree, deg)
 
     L, deg = glap(mtx_res)
     lapl, degree = laplacian.compute_laplacian(mtx, negval="rescale", selfloops=True)
-    assert np.allclose(lapl, L)
-    assert np.allclose(degree, deg)
+    assert_allclose(lapl, L)
+    assert_allclose(degree, deg)
 
 
 def test_normalisation():


### PR DESCRIPTION
`assert_allclose` has a saner `atol=0` and a more informative message on failure than `np.allclose`. 

## Change Type
<!-- Indicate the type of change you think your pull request is -->
- [ ] `bugfix` (+0.0.1)
- [ ] `minor` (+0.1.0)
- [ ] `major`  (+1.0.0)
- [ ] `refactoring` (no version update)
- [x] `test` (no version update)
- [ ] `infrastructure` (no version update)
- [ ] `documentation` (no version update)
- [ ] `other`
